### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/matthewwalker499/be1f6c05-6a4a-4a4c-b458-999ea6e14901/8db9f0c2-e0b0-4c7e-ab41-170847b9b1b0/_apis/work/boardbadge/7cf4d168-d37f-474e-ab12-47dd4b72f9d3)](https://dev.azure.com/matthewwalker499/be1f6c05-6a4a-4a4c-b458-999ea6e14901/_boards/board/t/8db9f0c2-e0b0-4c7e-ab41-170847b9b1b0/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/matthewwalker499/be1f6c05-6a4a-4a4c-b458-999ea6e14901/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.